### PR TITLE
extrai classes rendimentos, dependentes e deduções

### DIFF
--- a/src/app/Deducoes.java
+++ b/src/app/Deducoes.java
@@ -1,0 +1,155 @@
+package app;
+
+public class Deducoes {
+    int numContribuicaoPrevidenciaria;
+    float totalContribuicaoPrevidenciaria;
+    float totalPensaoAlimenticia;
+    String[] nomesDeducoes;
+    float[] valoresDeducoes;
+    private IRPF irpf;
+
+
+    public Deducoes(IRPF irpf) {
+        this.irpf = irpf;
+    }
+
+    /**
+     * Return o valor do total de deduções para o contribuinte
+     *
+     * @return valor total de deducoes
+     */
+    public float getDeducao() {
+        float total = 0;
+        for (String d : irpf.getNomesDependentes()) {
+            total += 189.59f;
+        }
+        total += totalContribuicaoPrevidenciaria;
+
+        return total;
+    }
+
+    /**
+     * Cadastra um valor de contribuição previdenciária oficial
+     *
+     * @param contribuicao valor da contribuição previdenciária oficial
+     */
+    public void cadastrarContribuicaoPrevidenciaria(float contribuicao) {
+        numContribuicaoPrevidenciaria++;
+        totalContribuicaoPrevidenciaria += contribuicao;
+    }
+
+    /**
+     * Retorna o numero total de contribuições realizadas como contribuicao
+     * previdenciaria oficial
+     *
+     * @return numero de contribuições realizadas
+     */
+    public int getNumContribuicoesPrevidenciarias() {
+        return numContribuicaoPrevidenciaria;
+    }
+
+    /**
+     * Retorna o valor total de contribuições oficiais realizadas
+     *
+     * @return valor total de contribuições oficiais
+     */
+    public float getTotalContribuicoesPrevidenciarias() {
+        return totalContribuicaoPrevidenciaria;
+    }
+
+    /**
+     * Realiza o cadastro de uma pensao alimenticia para um dos dependentes do
+     * contribuinte, caso ele seja um filho ou alimentando.
+     *
+     * @param dependente nome do dependente
+     * @param valor      valor da pensao alimenticia
+     */
+    public void cadastrarPensaoAlimenticia(String dependente, float valor) {
+        String parentesco = irpf.getParentesco(dependente);
+        if (parentesco.toLowerCase().contains("filh") ||
+                parentesco.toLowerCase().contains("alimentand")) {
+            totalPensaoAlimenticia += valor;
+        }
+    }
+
+    /**
+     * Retorna o valor total pago em pensões alimentícias pelo contribuinte.
+     *
+     * @return valor total de pensoes alimenticias
+     */
+    public float getTotalPensaoAlimenticia() {
+        return totalPensaoAlimenticia;
+    }
+
+    /**
+     * Metodo para cadastrar deduções integrais para o contribuinte. Para cada
+     * dedução é informado seu nome e valor.
+     *
+     * @param nome         nome da deducao
+     * @param valorDeducao valor da deducao
+     */
+    public void cadastrarDeducaoIntegral(String nome, float valorDeducao) {
+        nomesDeducoes = cadastroNomeDeducao(nome);
+        valoresDeducoes = cadastroValorDeducao(valorDeducao);
+    }
+
+    String[] cadastroNomeDeducao(String nome) {
+        String[] temp = new String[nomesDeducoes.length + 1];
+        for (int i = 0; i < nomesDeducoes.length; i++) {
+            temp[i] = nomesDeducoes[i];
+        }
+        temp[nomesDeducoes.length] = nome;
+        return temp;
+    }
+
+    float[] cadastroValorDeducao(float valorDeducao) {
+        float[] temp = new float[valoresDeducoes.length + 1];
+        for (int i = 0; i < valoresDeducoes.length; i++) {
+            temp[i] = valoresDeducoes[i];
+        }
+        temp[valoresDeducoes.length] = valorDeducao;
+        return temp;
+    }
+
+    /**
+     * Método para pesquisar uma deducao pelo seu nome.
+     *
+     * @param substring do nome da deducao a ser pesquisada
+     * @return nome da deducao, ou null caso na esteja cadastrada
+     */
+    public String getOutrasDeducoes(String nome) {
+        for (String d : nomesDeducoes) {
+            if (d.toLowerCase().contains(nome.toLowerCase()))
+                return d;
+        }
+        return null;
+    }
+
+    /**
+     * Obtem o valor da deducao à partir de seu nome
+     *
+     * @param nome nome da deducao para a qual se busca seu valor
+     * @return valor da deducao
+     */
+    public float getDeducao(String nome) {
+        for (int i = 0; i < nomesDeducoes.length; i++) {
+            if (nomesDeducoes[i].toLowerCase().contains(nome.toLowerCase()))
+                return valoresDeducoes[i];
+        }
+        return 0;
+    }
+
+    /**
+     * Obtem o valor total de todas as deduções que nao sao do tipo
+     * contribuicoes previdenciarias ou por dependentes
+     *
+     * @return valor total das outras deducoes
+     */
+    public float getTotalOutrasDeducoes() {
+        float soma = 0;
+        for (float f : valoresDeducoes) {
+            soma += f;
+        }
+        return soma;
+    }
+}

--- a/src/app/Dependentes.java
+++ b/src/app/Dependentes.java
@@ -1,13 +1,11 @@
 package app;
 
 public class Dependentes {
-    private final app.IRPF IRPF;
-    String[] nomesDependentes;
+    public String[] nomesDependentes;
     String[] parentescosDependentes;
     public int numDependentes;
 
-    public Dependentes(app.IRPF IRPF) {
-        this.IRPF = IRPF;
+    public Dependentes() {
     }
 
     /**
@@ -58,5 +56,9 @@ public class Dependentes {
                 return d;
         }
         return null;
+    }
+
+    public String[] getNomesDependentes() {
+        return nomesDependentes;
     }
 }

--- a/src/app/Dependentes.java
+++ b/src/app/Dependentes.java
@@ -1,0 +1,62 @@
+package app;
+
+public class Dependentes {
+    private final app.IRPF IRPF;
+    String[] nomesDependentes;
+    String[] parentescosDependentes;
+    public int numDependentes;
+
+    public Dependentes(app.IRPF IRPF) {
+        this.IRPF = IRPF;
+    }
+
+    /**
+     * Método para realizar o cadastro de um dependente, informando seu grau
+     * de parentesco
+     *
+     * @param nome       Nome do dependente
+     * @param parentesco Grau de parentesco
+     */
+    public void cadastrarDependente(String nome, String parentesco) {
+        // adicionar dependente
+        String[] temp = new String[nomesDependentes.length + 1];
+        for (int i = 0; i < nomesDependentes.length; i++) {
+            temp[i] = nomesDependentes[i];
+        }
+        temp[nomesDependentes.length] = nome;
+        nomesDependentes = temp;
+
+        String[] temp2 = new String[parentescosDependentes.length + 1];
+        for (int i = 0; i < parentescosDependentes.length; i++) {
+            temp2[i] = parentescosDependentes[i];
+        }
+        temp2[parentescosDependentes.length] = parentesco;
+        parentescosDependentes = temp2;
+
+//        IRPF.setNumDependentes(IRPF.getNumDependentes() + 1);
+        numDependentes++;
+    }
+
+    /**
+     * Método que retorna o numero de dependentes do contribuinte
+     *
+     * @return numero de dependentes
+     */
+    public int getNumDependentes() {
+        return numDependentes;
+    }
+
+    /**
+     * Realiza busca do dependente no cadastro do contribuinte
+     *
+     * @param nome nome do dependente que está sendo pesquisado
+     * @return nome do dependente ou null, caso nao conste na lista de dependentes
+     */
+    public String getDependente(String nome) {
+        for (String d : nomesDependentes) {
+            if (d.contains(nome))
+                return d;
+        }
+        return null;
+    }
+}

--- a/src/app/IRPF.java
+++ b/src/app/IRPF.java
@@ -14,6 +14,9 @@ public class IRPF {
 	private String[] nomesDependentes;
 	private String[] parentescosDependentes;
 	private int numDependentes;
+
+	private final Rendimentos rendimentos = new Rendimentos();
+	private final Dependentes dependentes = new Dependentes(this);
 	
 	private int numContribuicaoPrevidenciaria;
 	private float totalContribuicaoPrevidenciaria;
@@ -24,13 +27,13 @@ public class IRPF {
 	private float[] valoresDeducoes;
 
 	public IRPF() {
-		nomeRendimento = new String[0];
-		rendimentoTributavel = new boolean[0];
-		valorRendimento = new float[0];
-		
-		nomesDependentes = new String[0];
-		parentescosDependentes = new String[0];
-		numDependentes = 0;
+        rendimentos.nomeRendimento = new String[0];
+        rendimentos.rendimentoTributavel = new boolean[0];
+        rendimentos.valorRendimento = new float[0];
+
+		dependentes.nomesDependentes = new String[0];
+		dependentes.parentescosDependentes = new String[0];
+		dependentes.numDependentes = 0;
 		
 		numContribuicaoPrevidenciaria = 0; 
 		totalContribuicaoPrevidenciaria = 0f;
@@ -40,70 +43,45 @@ public class IRPF {
 		nomesDeducoes = new String[0];
 		valoresDeducoes = new float[0];
 	}
-	
+
 	/**
-	 * Cadastra um rendimento na base do contribuinte, informando o nome do 
-	 * rendimento, seu valor e se ele é tributável ou não. 
-	 * @param nome nome do rendimento a ser cadastrado
+	 * Cadastra um rendimento na base do contribuinte, informando o nome do
+	 * rendimento, seu valor e se ele é tributável ou não.
+	 *
+	 * @param nome       nome do rendimento a ser cadastrado
 	 * @param tributavel true caso seja tributável, false caso contrário
-	 * @param valor valor do rendimento a ser cadastrado
+	 * @param valor      valor do rendimento a ser cadastrado
 	 */
 	public void criarRendimento(String nome, boolean tributavel, float valor) {
-		//Adicionar o nome do novo rendimento
-		String[] temp = new String[nomeRendimento.length + 1];
-		for (int i=0; i<nomeRendimento.length; i++)
-			temp[i] = nomeRendimento[i];
-		temp[nomeRendimento.length] = nome;
-		nomeRendimento = temp;
-
-		//adicionar tributavel ou nao no vetor 
-		boolean[] temp2 = new boolean[rendimentoTributavel.length + 1];
-		for (int i=0; i<rendimentoTributavel.length; i++) 
-			temp2[i] = rendimentoTributavel[i];
-		temp2[rendimentoTributavel.length] = tributavel;
-		rendimentoTributavel = temp2;
-		
-		//adicionar valor rendimento ao vetor
-		float[] temp3 = new float[valorRendimento.length + 1];
-		for (int i=0; i<valorRendimento.length; i++) {
-			temp3[i] = valorRendimento[i];
-		}
-		temp3[valorRendimento.length] = valor; 
-		valorRendimento = temp3;
-		
-		this.numRendimentos += 1;
-		this.totalRendimentos += valor;
-		
+		rendimentos.criarRendimento(nome, tributavel, valor);
 	}
 
 	/**
 	 * Retorna o número de rendimentos já cadastrados para o contribuinte
+	 *
 	 * @return numero de rendimentos
 	 */
 	public int getNumRendimentos() {
-		return numRendimentos;
+		return rendimentos.numRendimentos;
 	}
 
 	/**
 	 * Retorna o valor total de rendimentos cadastrados para o contribuinte
+	 *
 	 * @return valor total dos rendimentos
 	 */
 	public float getTotalRendimentos() {
-		return totalRendimentos;
+		return rendimentos.totalRendimentos;
 	}
 
 	/**
 	 * Retorna o valor total de rendimentos tributáveis do contribuinte
+	 *
 	 * @return valor total dos rendimentos tributáveis
 	 */
 	public float getTotalRendimentosTributaveis() {
-		float totalRendimentosTributaveis = 0;
-		for (int i=0; i<rendimentoTributavel.length; i++) {
-			if (rendimentoTributavel[i]) {
-				totalRendimentosTributaveis += valorRendimento[i];
-			}
-		}
-		return totalRendimentosTributaveis;
+
+		return rendimentos.getTotalRendimentosTributaveis();
 	}
 
 	/**
@@ -113,22 +91,8 @@ public class IRPF {
 	 * @param parentesco Grau de parentesco
 	 */
 	public void cadastrarDependente(String nome, String parentesco) {
-		// adicionar dependente 
-		String[] temp = new String[nomesDependentes.length + 1];
-		for (int i=0; i<nomesDependentes.length; i++) {
-			temp[i] = nomesDependentes[i];
-		}
-		temp[nomesDependentes.length] = nome;
-		nomesDependentes = temp;
-		
-		String[] temp2 = new String[parentescosDependentes.length + 1];
-		for (int i=0; i<parentescosDependentes.length; i++) {
-			temp2[i] = parentescosDependentes[i];
-		}
-		temp2[parentescosDependentes.length] = parentesco;
-		parentescosDependentes = temp2;
-		
-		numDependentes++;
+		// adicionar dependente
+		dependentes.cadastrarDependente(nome, parentesco);
 	}
 
 	/**
@@ -136,7 +100,7 @@ public class IRPF {
 	 * @return numero de dependentes
 	 */
 	public int getNumDependentes() {
-		return numDependentes;
+		return dependentes.getNumDependentes();
 	}
 	
 	/**
@@ -145,7 +109,7 @@ public class IRPF {
 	 */
 	public float getDeducao() {
 		float total = 0; 
-		for (String d: nomesDependentes) {
+		for (String d: dependentes.nomesDependentes) {
 			total += 189.59f;
 		}
 		total += totalContribuicaoPrevidenciaria;
@@ -185,11 +149,7 @@ public class IRPF {
 	 * @return nome do dependente ou null, caso nao conste na lista de dependentes
 	 */
 	public String getDependente(String nome) {
-		for (String d : nomesDependentes) {
-			if (d.contains(nome))
-				return d;
-		}
-		return null;
+		return dependentes.getDependente(nome);
 	}
 
 	/**
@@ -199,9 +159,9 @@ public class IRPF {
 	 * @return grau de parentesco, nulo caso nao exista o dependente
 	 */
 	public String getParentesco(String dependente) {
-		for (int i = 0; i<nomesDependentes.length; i++) {
-			if (nomesDependentes[i].equalsIgnoreCase(dependente))
-				return parentescosDependentes[i];
+		for (int i = 0; i< dependentes.nomesDependentes.length; i++) {
+			if (dependentes.nomesDependentes[i].equalsIgnoreCase(dependente))
+				return dependentes.parentescosDependentes[i];
 		}
 		return null;
 	}
@@ -302,7 +262,7 @@ public class IRPF {
 	* na diferença do total di Rendimento Tributável com o total das Deduções
 	*/
 	public float getBaseCalculoImposto() {
-		float totalTributavel = getTotalRendimentosTributaveis();
+		float totalTributavel = rendimentos.getTotalRendimentosTributaveis();
 		float totalDeducoes = getDeducao() + getTotalPensaoAlimenticia() + getTotalOutrasDeducoes();
 
 		return totalTributavel - totalDeducoes;
@@ -336,7 +296,7 @@ public class IRPF {
     }
 
 	public float getAliquotaEfetiva() {
-		return (calcularImposto() / getTotalRendimentosTributaveis()) * 100;
+		return (calcularImposto() / rendimentos.getTotalRendimentosTributaveis()) * 100;
 	}
 
 }

--- a/src/app/IRPF.java
+++ b/src/app/IRPF.java
@@ -16,15 +16,8 @@ public class IRPF {
 	private int numDependentes;
 
 	private final Rendimentos rendimentos = new Rendimentos();
-	private final Dependentes dependentes = new Dependentes(this);
-	
-	private int numContribuicaoPrevidenciaria;
-	private float totalContribuicaoPrevidenciaria;
-	
-	private float totalPensaoAlimenticia;
-	
-	private String[] nomesDeducoes;
-	private float[] valoresDeducoes;
+	private final Dependentes dependentes = new Dependentes();
+	private final Deducoes deducoes = new Deducoes(this);
 
 	public IRPF() {
         rendimentos.nomeRendimento = new String[0];
@@ -34,14 +27,14 @@ public class IRPF {
 		dependentes.nomesDependentes = new String[0];
 		dependentes.parentescosDependentes = new String[0];
 		dependentes.numDependentes = 0;
-		
-		numContribuicaoPrevidenciaria = 0; 
-		totalContribuicaoPrevidenciaria = 0f;
-		
-		totalPensaoAlimenticia = 0f;
-		
-		nomesDeducoes = new String[0];
-		valoresDeducoes = new float[0];
+
+		deducoes.numContribuicaoPrevidenciaria = 0;
+		deducoes.totalContribuicaoPrevidenciaria = 0f;
+
+		deducoes.totalPensaoAlimenticia = 0f;
+
+		deducoes.nomesDeducoes = new String[0];
+		deducoes.valoresDeducoes = new float[0];
 	}
 
 	/**
@@ -108,13 +101,8 @@ public class IRPF {
 	 * @return valor total de deducoes
 	 */
 	public float getDeducao() {
-		float total = 0; 
-		for (String d: dependentes.nomesDependentes) {
-			total += 189.59f;
-		}
-		total += totalContribuicaoPrevidenciaria;
-		
-		return total;
+
+		return deducoes.getDeducao();
 	}
 
 	/**
@@ -122,8 +110,7 @@ public class IRPF {
 	 * @param contribuicao valor da contribuição previdenciária oficial
 	 */
 	public void cadastrarContribuicaoPrevidenciaria(float contribuicao) {
-		numContribuicaoPrevidenciaria++;
-		totalContribuicaoPrevidenciaria += contribuicao;
+		deducoes.cadastrarContribuicaoPrevidenciaria(contribuicao);
 	}
 
 	/**
@@ -132,7 +119,7 @@ public class IRPF {
 	 * @return numero de contribuições realizadas
 	 */
 	public int getNumContribuicoesPrevidenciarias() {
-		return numContribuicaoPrevidenciaria;
+		return deducoes.getNumContribuicoesPrevidenciarias();
 	}
 
 	/**
@@ -140,7 +127,7 @@ public class IRPF {
 	 * @return valor total de contribuições oficiais
 	 */
 	public float getTotalContribuicoesPrevidenciarias() {
-		return totalContribuicaoPrevidenciaria;
+		return deducoes.getTotalContribuicoesPrevidenciarias();
 	}
 
 	/**
@@ -150,6 +137,10 @@ public class IRPF {
 	 */
 	public String getDependente(String nome) {
 		return dependentes.getDependente(nome);
+	}
+
+	public String[] getNomesDependentes() {
+		return dependentes.getNomesDependentes();
 	}
 
 	/**
@@ -173,11 +164,7 @@ public class IRPF {
 	 * @param valor valor da pensao alimenticia
 	 */
 	public void cadastrarPensaoAlimenticia(String dependente, float valor) {
-		String parentesco = getParentesco(dependente); 
-		if (parentesco.toLowerCase().contains("filh") || 
-			parentesco.toLowerCase().contains("alimentand")) {
-			totalPensaoAlimenticia += valor;
-		}
+		deducoes.cadastrarPensaoAlimenticia(dependente, valor);
 	}
 
 	/**
@@ -185,7 +172,7 @@ public class IRPF {
 	 * @return valor total de pensoes alimenticias
 	 */
 	public float getTotalPensaoAlimenticia() {
-		return totalPensaoAlimenticia;
+		return deducoes.getTotalPensaoAlimenticia();
 	}
 
 	/**
@@ -195,26 +182,15 @@ public class IRPF {
 	 * @param valorDeducao valor da deducao
 	 */
 	public void cadastrarDeducaoIntegral(String nome, float valorDeducao) {
-		nomesDeducoes = cadastroNomeDeducao(nome);
-		valoresDeducoes= cadastroValorDeducao(valorDeducao);
+		deducoes.cadastrarDeducaoIntegral(nome, valorDeducao);
 	}
 
 	private String[] cadastroNomeDeducao(String nome) {
-		String[] temp = new String[nomesDeducoes.length + 1];
-		for (int i=0; i<nomesDeducoes.length; i++) {
-			temp[i] = nomesDeducoes[i];
-		}
-		temp[nomesDeducoes.length] = nome;
-		return temp;
+		return deducoes.cadastroNomeDeducao(nome);
 	}
 
 	private float[] cadastroValorDeducao(float valorDeducao) {
-		float[] temp = new float[valoresDeducoes.length + 1];
-		for (int i=0; i<valoresDeducoes.length; i++) {
-			temp[i] = valoresDeducoes[i];
-		}
-		temp[valoresDeducoes.length] = valorDeducao;
-		return temp;
+		return deducoes.cadastroValorDeducao(valorDeducao);
 	}
 
 	/**
@@ -223,11 +199,7 @@ public class IRPF {
 	 * @return nome da deducao, ou null caso na esteja cadastrada
 	 */
 	public String getOutrasDeducoes(String nome) {
-		for (String d : nomesDeducoes) {
-			if (d.toLowerCase().contains(nome.toLowerCase()))
-				return d;
-		}
-		return null;
+		return deducoes.getOutrasDeducoes(nome);
 	}
 
 	/**
@@ -236,11 +208,7 @@ public class IRPF {
 	 * @return valor da deducao
 	 */
 	public float getDeducao(String nome) {
-		for (int i=0; i<nomesDeducoes.length; i++) {
-			if (nomesDeducoes[i].toLowerCase().contains(nome.toLowerCase()))
-				return valoresDeducoes[i];
-		}
-		return 0;
+		return deducoes.getDeducao(nome);
 	}
 
 	/**
@@ -249,11 +217,7 @@ public class IRPF {
 	 * @return valor total das outras deducoes
 	 */
 	public float getTotalOutrasDeducoes() {
-		float soma = 0;
-		for (float f : valoresDeducoes) {
-			soma += f;
-		}
-		return soma;
+		return deducoes.getTotalOutrasDeducoes();
 	}
 
 	/**
@@ -263,7 +227,7 @@ public class IRPF {
 	*/
 	public float getBaseCalculoImposto() {
 		float totalTributavel = rendimentos.getTotalRendimentosTributaveis();
-		float totalDeducoes = getDeducao() + getTotalPensaoAlimenticia() + getTotalOutrasDeducoes();
+		float totalDeducoes = deducoes.getDeducao() + deducoes.getTotalPensaoAlimenticia() + deducoes.getTotalOutrasDeducoes();
 
 		return totalTributavel - totalDeducoes;
 	}

--- a/src/app/Rendimentos.java
+++ b/src/app/Rendimentos.java
@@ -1,0 +1,81 @@
+package app;
+
+public class Rendimentos {
+    String[] nomeRendimento;
+    boolean[] rendimentoTributavel;
+    float[] valorRendimento;
+    int numRendimentos;
+    float totalRendimentos;
+
+    public Rendimentos() {
+    }
+
+    /**
+     * Cadastra um rendimento na base do contribuinte, informando o nome do
+     * rendimento, seu valor e se ele é tributável ou não.
+     *
+     * @param nome       nome do rendimento a ser cadastrado
+     * @param tributavel true caso seja tributável, false caso contrário
+     * @param valor      valor do rendimento a ser cadastrado
+     */
+    public void criarRendimento(String nome, boolean tributavel, float valor) {
+        //Adicionar o nome do novo rendimento
+        String[] temp = new String[nomeRendimento.length + 1];
+        for (int i = 0; i < nomeRendimento.length; i++)
+            temp[i] = nomeRendimento[i];
+        temp[nomeRendimento.length] = nome;
+        nomeRendimento = temp;
+
+        //adicionar tributavel ou nao no vetor
+        boolean[] temp2 = new boolean[rendimentoTributavel.length + 1];
+        for (int i = 0; i < rendimentoTributavel.length; i++)
+            temp2[i] = rendimentoTributavel[i];
+        temp2[rendimentoTributavel.length] = tributavel;
+        rendimentoTributavel = temp2;
+
+        //adicionar valor rendimento ao vetor
+        float[] temp3 = new float[valorRendimento.length + 1];
+        for (int i = 0; i < valorRendimento.length; i++) {
+            temp3[i] = valorRendimento[i];
+        }
+        temp3[valorRendimento.length] = valor;
+        valorRendimento = temp3;
+
+        this.numRendimentos += 1;
+        this.totalRendimentos += valor;
+
+    }
+
+    /**
+     * Retorna o número de rendimentos já cadastrados para o contribuinte
+     *
+     * @return numero de rendimentos
+     */
+    public int getNumRendimentos() {
+        return numRendimentos;
+    }
+
+    /**
+     * Retorna o valor total de rendimentos cadastrados para o contribuinte
+     *
+     * @return valor total dos rendimentos
+     */
+    public float getTotalRendimentos() {
+        return totalRendimentos;
+    }
+
+    /**
+     * Retorna o valor total de rendimentos tributáveis do contribuinte
+     *
+     * @return valor total dos rendimentos tributáveis
+     */
+    public float getTotalRendimentosTributaveis() {
+        float totalRendimentosTributaveis = 0;
+        for (int i = 0; i < rendimentoTributavel.length; i++) {
+            if (rendimentoTributavel[i]) {
+                totalRendimentosTributaveis += valorRendimento[i];
+            }
+        }
+        return totalRendimentosTributaveis;
+    }
+}


### PR DESCRIPTION
Foi escolhido extrair essas classes por estarem altamente acopladas a classe IRPF, sendo assim, encapsulamos as suas respectivas responsabilidades específicas.

Com isso, a classe IRPF fica mais limpa e fácil de se manter

